### PR TITLE
feat: upgrade @leancloud/play to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -238,15 +238,30 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.1.tgz",
-      "integrity": "sha512-2dd6soo60cwKNJ90VewNLIzdZPR/E2YhszOTgHpN9V0YuwZk7x33/iZoIBnASwDFVHMY7iJ6NPL8d9f/DWYCTA==",
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "dev": true,
       "requires": {
+        "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -256,13 +271,10 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.17.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.17.1.tgz",
-      "integrity": "sha512-TA2/doAur5Ol8+iM3Ov7qy3jYcr/QiJ2eDTdRF4dfbjG7AaaB99J5G+zSl11ljbl6cIcahgPY6SKb3sC3EJ0fw==",
-      "dev": true,
-      "requires": {
-        "handlebars": "^4.5.3"
-      }
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -303,9 +315,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
       "dev": true
     },
     "js-tokens": {
@@ -334,9 +346,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash-decorators": {
       "version": "6.0.1",
@@ -377,19 +389,21 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
       }
     },
     "ms": {
@@ -415,16 +429,6 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
       }
     },
     "p-finally": {
@@ -639,12 +643,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
   "dependencies": {
     "debug": "^4.1.1",
     "ioredis": "^4.14.1",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.20",
     "lodash-decorators": "^6.0.1",
     "nanoid": "^2.1.9",
     "p-queue": "^6.2.1"
   },
   "peerDependencies": {
-    "@leancloud/play": "^0.18.0-beta.10",
+    "@leancloud/play": "^1.0.0",
     "rxjs": "^6.5.4"
   }
 }

--- a/src/game-manager.ts
+++ b/src/game-manager.ts
@@ -41,7 +41,7 @@ export interface ICreateGameOptions {
 }
 
 interface IGameManagerConfig<T extends Game> {
-  gameClass: IGameConstructor<T>;
+  gameConstructor: IGameConstructor<T>;
   appId: string;
   appKey: string;
   playServer?: string;
@@ -64,7 +64,7 @@ export class GameManager<T extends Game> extends EventEmitter {
     return this.games.size;
   }
   public open = true;
-  protected gameClass: IGameConstructor<T>;
+  protected gameConstructor: IGameConstructor<T>;
   protected appId: string;
   protected appKey: string;
   protected playServer: string | undefined;
@@ -73,7 +73,7 @@ export class GameManager<T extends Game> extends EventEmitter {
   protected reservationHoldTime: number;
 
   constructor({
-    gameClass,
+    gameConstructor,
     appId,
     appKey,
     playServer,
@@ -81,7 +81,7 @@ export class GameManager<T extends Game> extends EventEmitter {
     reservationHoldTime = 10000,
   }: IGameManagerConfig<T>) {
     super();
-    this.gameClass = gameClass;
+    this.gameConstructor = gameConstructor;
     this.appId = appId;
     this.appKey = appKey;
     this.playServer = playServer;
@@ -199,18 +199,18 @@ export class GameManager<T extends Game> extends EventEmitter {
   protected async createEmptyGame(options: ICreateGameOptions = {}) {
     const {
       expectedUserIds,
-      seatCount = this.gameClass.defaultSeatCount,
+      seatCount = this.gameConstructor.defaultSeatCount,
       roomName,
       roomOptions,
     } = options;
     const {
-      gameClass,
+      gameConstructor,
     } = this;
-    if (gameClass.maxSeatCount && seatCount > gameClass.maxSeatCount) {
-      throw new Error(`seatCount too large. The maxSeatCount is ${gameClass.maxSeatCount}`);
+    if (gameConstructor.maxSeatCount && seatCount > gameConstructor.maxSeatCount) {
+      throw new Error(`seatCount too large. The maxSeatCount is ${gameConstructor.maxSeatCount}`);
     }
-    if (gameClass.minSeatCount && seatCount < gameClass.minSeatCount) {
-      throw new Error(`seatCount too small. The minSeatCount is ${gameClass.minSeatCount}`);
+    if (gameConstructor.minSeatCount && seatCount < gameConstructor.minSeatCount) {
+      throw new Error(`seatCount too small. The minSeatCount is ${gameConstructor.minSeatCount}`);
     }
     const masterClient = this.createMasterClient();
     await masterClient.connect();
@@ -228,7 +228,7 @@ export class GameManager<T extends Game> extends EventEmitter {
         maxPlayerCount: seatCount + 1, // masterClient should be included
       },
     });
-    return new gameClass(room, masterClient);
+    return new gameConstructor(room, masterClient);
   }
 
   protected remove(game: T) {


### PR DESCRIPTION
### 说明

- 将 `@leancloud/play` 的版本从 v0.18.0-beta.10 升级到 v1.0.0
- 跑了下 `npm audit fix`
- 因为 `Client` 不再支持非国际节点且不提供 `playServer` 的使用方式，重构了下 `GameManager` 的构造函数